### PR TITLE
Pin dev dependencies to their exact version and group them in dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,8 @@ updates:
       interval: monthly
   - package-ecosystem: cargo
     directory: /
+    groups:
+      dev-dependencies:
+        dependency-type: development
     schedule:
       interval: monthly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ thiserror = "1.0.50"
 
 [dev-dependencies]
 codspeed-criterion-compat = "=2.7.1"
-criterion = "0.5.1"
-proptest = "1.4.0"
-rstest = "0.22.0"
+criterion = "=0.5.1"
+proptest = "=1.5.0"
+rstest = "=0.22.0"
 
 [features]
 default = ["simd"]


### PR DESCRIPTION
Pins development dependencies to their exact latest version. Upgrades will be performed monthly by dependabot.