### PR TITLE
Allow for extended ASCII chars in attribute values 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpsl-rs"
-description = "An RFC 2622 conformant Routing Policy Specification Language (RPSL) parser with a focus on speed and correctness."
+description = "A Routing Policy Specification Language (RPSL) parser with a focus on speed and correctness."
 version = "1.0.1"
 keywords = ["rpsl", "parser", "routing", "policy", "whois"]
 categories = ["parsing", "database"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </div>
 <br>
 
-An [RFC 2622] conformant Routing Policy Specification Language (RPSL) parser with a focus on speed and correctness.
+A Routing Policy Specification Language (RPSL) parser with a focus on speed and correctness.
 
 ⚡️ 130-250x faster than other parsers\
 📰 Complete implementation for multiline RPSL values\
@@ -173,7 +173,6 @@ To get started, please read the [contribution guidelines](.github/CONTRIBUTING.m
 
 The source code of this project is licensed under the MIT License. For more information, see [LICENSE](LICENSE).
 
-[RFC 2622]: https://datatracker.ietf.org/doc/html/rfc2622
 [Object]: https://docs.rs/rpsl-rs/latest/rpsl/struct.Object.html
 [Attribute]: https://docs.rs/rpsl-rs/latest/rpsl/struct.Attribute.html
 [parse_object]: https://docs.rs/rpsl-rs/latest/rpsl/fn.parse_object.html

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -215,9 +215,14 @@ impl<'a> Value<'a> {
     }
 
     fn validate(value: &str) -> Result<(), InvalidValueError> {
-        if value.chars().any(|c| !matches!(c, '\u{0000}'..='\u{00FF}')) {
+        value.chars().try_for_each(Self::validate_char)
+    }
+
+    #[inline]
+    pub(crate) fn validate_char(c: char) -> Result<(), InvalidValueError> {
+        if !is_extended_ascii(c) {
             return Err(InvalidValueError::NonExtendedAscii);
-        } else if value.chars().any(|c| c.is_ascii_control()) {
+        } else if c.is_ascii_control() {
             return Err(InvalidValueError::ContainsControlChar);
         }
 
@@ -411,6 +416,12 @@ where
     } else {
         Some(value)
     }
+}
+
+/// Checks if the given char is part of the extended ASCII set.
+#[inline]
+fn is_extended_ascii(char: char) -> bool {
+    matches!(char, '\u{0000}'..='\u{00FF}')
 }
 
 #[cfg(test)]

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -215,7 +215,7 @@ impl<'a> Value<'a> {
     }
 
     fn validate(value: &str) -> Result<(), InvalidValueError> {
-        if !value.is_ascii() {
+        if value.chars().any(|c| !matches!(c, '\u{0000}'..='\u{00FF}')) {
             return Err(InvalidValueError::NonAscii);
         } else if value.chars().any(|c| c.is_ascii_control()) {
             return Err(InvalidValueError::ContainsControlChar);

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -223,6 +223,8 @@ impl<'a> Value<'a> {
         value.chars().try_for_each(Self::validate_char)
     }
 
+    /// Even though RFC 2622 requires values to be ASCII, in practice some WHOIS databases
+    /// (e.g. RIPE) do not enforce this so, to be useful in the real world, we don't either.
     #[inline]
     pub(crate) fn validate_char(c: char) -> Result<(), InvalidValueError> {
         if !is_extended_ascii(c) {

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -216,7 +216,7 @@ impl<'a> Value<'a> {
 
     fn validate(value: &str) -> Result<(), InvalidValueError> {
         if value.chars().any(|c| !matches!(c, '\u{0000}'..='\u{00FF}')) {
-            return Err(InvalidValueError::NonAscii);
+            return Err(InvalidValueError::NonExtendedAscii);
         } else if value.chars().any(|c| c.is_ascii_control()) {
             return Err(InvalidValueError::ContainsControlChar);
         }
@@ -574,7 +574,7 @@ mod tests {
     proptest! {
         #[test]
         fn value_validation_any_non_extended_ascii_is_err(s in r"[^\x00-\xFF]+") {
-            matches!(Value::validate(&s).unwrap_err(), InvalidValueError::NonAscii);
+            matches!(Value::validate(&s).unwrap_err(), InvalidValueError::NonExtendedAscii);
         }
     }
 

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -585,16 +585,12 @@ mod tests {
             {
                 Value::validate(&s).unwrap();
         }
-    }
 
-    proptest! {
         #[test]
         fn value_validation_any_non_extended_ascii_is_err(s in r"[^\x00-\xFF]+") {
             matches!(Value::validate(&s).unwrap_err(), InvalidValueError::NonExtendedAscii);
         }
-    }
 
-    proptest! {
         #[test]
         fn value_validation_any_ascii_control_is_err(s in r"[\x00-\x1F\x7F]+") {
             matches!(Value::validate(&s).unwrap_err(), InvalidValueError::ContainsControlChar);

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -98,6 +98,20 @@ impl<'a> Name<'a> {
     fn unchecked(name: &'a str) -> Self {
         Self(Cow::Borrowed(name))
     }
+
+    fn validate(name: &str) -> Result<(), InvalidNameError> {
+        if name.trim().is_empty() {
+            return Err(InvalidNameError::Empty);
+        } else if !name.is_ascii() {
+            return Err(InvalidNameError::NonAscii);
+        } else if !name.chars().next().unwrap().is_ascii_alphabetic() {
+            return Err(InvalidNameError::NonAsciiAlphabeticFirstChar);
+        } else if !name.chars().last().unwrap().is_ascii_alphanumeric() {
+            return Err(InvalidNameError::NonAsciiAlphanumericLastChar);
+        }
+
+        Ok(())
+    }
 }
 
 impl FromStr for Name<'_> {
@@ -111,16 +125,7 @@ impl FromStr for Name<'_> {
     /// # Errors
     /// Returns an error if the name is empty or invalid.
     fn from_str(name: &str) -> Result<Self, Self::Err> {
-        if name.trim().is_empty() {
-            return Err(InvalidNameError::Empty);
-        } else if !name.is_ascii() {
-            return Err(InvalidNameError::NonAscii);
-        } else if !name.chars().next().unwrap().is_ascii_alphabetic() {
-            return Err(InvalidNameError::NonAsciiAlphabeticFirstChar);
-        } else if !name.chars().last().unwrap().is_ascii_alphanumeric() {
-            return Err(InvalidNameError::NonAsciiAlphanumericLastChar);
-        }
-
+        Self::validate(name)?;
         Ok(Self(Cow::Owned(name.to_string())))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 pub enum InvalidNameError {
     #[error("cannot be empty")]
     Empty,
-    #[error("cannot contain non-ASCII characters")]
+    #[error("cannot contain characters that are not part of the extended ASCII set")]
     NonAscii,
     #[error("cannot start with a non-letter ASCII character")]
     NonAsciiAlphabeticFirstChar,
@@ -16,8 +16,8 @@ pub enum InvalidNameError {
 
 #[derive(Error, Debug)]
 pub enum InvalidValueError {
-    #[error("cannot contain non-ASCII characters")]
-    NonAscii,
+    #[error("cannot contain characters that are not part of the extended ASCII set")]
+    NonExtendedAscii,
     #[error("cannot contain ASCII control characters")]
     ContainsControlChar,
 }

--- a/src/parser/component.rs
+++ b/src/parser/component.rs
@@ -54,9 +54,12 @@ pub fn attribute_name<'s>(input: &mut &'s str) -> PResult<&'s str> {
         .parse_next(input)
 }
 
-// An ASCII sequence of characters, excluding control.
+// An extended ASCII sequence of characters, excluding control.
 pub fn attribute_value<'s>(input: &mut &'s str) -> PResult<&'s str> {
-    take_while(0.., |c: char| c.is_ascii() && !c.is_ascii_control()).parse_next(input)
+    take_while(0.., |c: char| {
+        matches!(c, '\u{0000}'..='\u{00FF}') && !c.is_ascii_control()
+    })
+    .parse_next(input)
 }
 
 // Extends an attributes value over multiple lines.

--- a/src/parser/component.rs
+++ b/src/parser/component.rs
@@ -80,6 +80,7 @@ pub fn consume_continuation_char(input: &mut &str) -> PResult<()> {
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
     use rstest::*;
 
     use super::*;
@@ -223,6 +224,15 @@ mod tests {
         let parsed = attribute_value(given).unwrap();
         assert_eq!(parsed, expected);
         assert_eq!(*given, remaining);
+    }
+
+    proptest! {
+        /// Any non extended ASCII is not returned by the value parser.
+        #[test]
+        fn attribute_value_non_extended_ascii_not_parsed(s in r"[^\x00-\xFF]+") {
+            let parsed = attribute_value(&mut s.as_str()).unwrap();
+            prop_assert_eq!(parsed, "");
+        }
     }
 
     #[rstest]

--- a/src/parser/component.rs
+++ b/src/parser/component.rs
@@ -7,7 +7,7 @@ use winnow::{
     PResult, Parser,
 };
 
-use crate::Attribute;
+use crate::{Attribute, Value};
 
 // A response code or message sent by the whois server.
 // Starts with the "%" character and extends until the end of the line.
@@ -56,10 +56,7 @@ pub fn attribute_name<'s>(input: &mut &'s str) -> PResult<&'s str> {
 
 // An extended ASCII sequence of characters, excluding control.
 pub fn attribute_value<'s>(input: &mut &'s str) -> PResult<&'s str> {
-    take_while(0.., |c: char| {
-        matches!(c, '\u{0000}'..='\u{00FF}') && !c.is_ascii_control()
-    })
-    .parse_next(input)
+    take_while(0.., |c| Value::validate_char(c).is_ok()).parse_next(input)
 }
 
 // Extends an attributes value over multiple lines.

--- a/tests/test_parsing.rs
+++ b/tests/test_parsing.rs
@@ -27,10 +27,20 @@ mod strategies {
 
     /// A valid attribute value.
     ///
-    /// An attribute value may consist of any ASCII characters excluding control and
-    /// must not start with, or consist entirely of whitespace.
+    /// An attribute value may consist of any characters from the extended ASCII set,
+    /// while excluding control and not starting with, or consisting entirely of whitespace.
     fn attribute_value_content() -> impl Strategy<Value = String> {
-        proptest::string::string_regex("[!-~][ -~]*").unwrap()
+        proptest::string::string_regex("[ -ÿ]+")
+            .unwrap()
+            .prop_filter("Cannot start with whitespace", |s| {
+                !s.starts_with(|c: char| c.is_whitespace())
+            })
+            .prop_filter("Cannot consist of whitespace only", |s| {
+                !s.trim().is_empty()
+            })
+            .prop_filter("Cannot contain control characters", |s| {
+                !s.chars().any(|c| c.is_control())
+            })
     }
 
     /// An empty attribute value.

--- a/tests/test_parsing.rs
+++ b/tests/test_parsing.rs
@@ -27,8 +27,8 @@ mod strategies {
 
     /// A valid attribute value.
     ///
-    /// An attribute value may consist of any characters from the extended ASCII set,
-    /// while excluding control and not starting with, or consisting entirely of whitespace.
+    /// Creates a string of extended ASCII characters while excluding control and not
+    /// starting with, or consisting entirely of whitespace.
     fn attribute_value_content() -> impl Strategy<Value = String> {
         proptest::string::string_regex(r"[\x20-\x7E\x80-\xFF]+")
             .unwrap()

--- a/tests/test_parsing.rs
+++ b/tests/test_parsing.rs
@@ -30,7 +30,7 @@ mod strategies {
     /// An attribute value may consist of any characters from the extended ASCII set,
     /// while excluding control and not starting with, or consisting entirely of whitespace.
     fn attribute_value_content() -> impl Strategy<Value = String> {
-        proptest::string::string_regex("[ -ÿ]+")
+        proptest::string::string_regex(r"[\x00-\xFF]+")
             .unwrap()
             .prop_filter("Cannot start with whitespace", |s| {
                 !s.starts_with(|c: char| c.is_whitespace())

--- a/tests/test_parsing.rs
+++ b/tests/test_parsing.rs
@@ -30,16 +30,13 @@ mod strategies {
     /// An attribute value may consist of any characters from the extended ASCII set,
     /// while excluding control and not starting with, or consisting entirely of whitespace.
     fn attribute_value_content() -> impl Strategy<Value = String> {
-        proptest::string::string_regex(r"[\x00-\xFF]+")
+        proptest::string::string_regex(r"[\x20-\x7E\x80-\xFF]+")
             .unwrap()
             .prop_filter("Cannot start with whitespace", |s| {
                 !s.starts_with(|c: char| c.is_whitespace())
             })
             .prop_filter("Cannot consist of whitespace only", |s| {
                 !s.trim().is_empty()
-            })
-            .prop_filter("Cannot contain control characters", |s| {
-                !s.chars().any(|c| c.is_control())
             })
     }
 


### PR DESCRIPTION
Allow for extended ASCII chars in attribute values, making the parser no longer fully conformant with RFC 2622. Since commonly used WHOIS  databases do not fully conform to the standard either, we need to follow suit to be a useful parser.