### PR TITLE
Revert unsupported Dependabot Cargo strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    versioning-strategy: increase-if-necessary
+    # `widen` or `increase-if-necessary` not supported for cargo
+    # https://github.com/SRv6d/rpsl-rs/issues/276
+    versioning-strategy: lockfile-only
     cooldown:
       default-days: 5
     open-pull-requests-limit: 8


### PR DESCRIPTION
GitHub's hosted Dependabot validator still rejects `increase-if-necessary` for Cargo, despite the public dependabot-core change and documentation.

Restore the last known valid `lockfile-only` configuration so Dependabot can run again. Keep #276 open until the hosted validator accepts the explicit strategy.

Failing check: https://github.com/SRv6d/rpsl-rs/runs/101398469370